### PR TITLE
Create incentive with max range

### DIFF
--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -132,6 +132,13 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
       address token1,
       uint24 fee
     ) external override {
+      IUniswapV3Pool pool = IUniswapV3Pool(
+          PoolAddress.computeAddress(
+              address(factory),
+              PoolAddress.PoolKey({token0: token0, token1: token1, fee: fee})
+          )
+      );
+
       int24 tickSpacing = IUniswapV3Pool(pool).tickSpacing();
 
       // full range max/min ticks for pool
@@ -141,12 +148,6 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
       // use max range for min width
       int24 minWidth = maxTick - minTick; // which is just 2 * maxTick
 
-      pool = IUniswapV3Pool(
-          PoolAddress.computeAddress(
-              address(factory),
-              PoolAddress.PoolKey({token0: token0, token1: token1, fee: fee})
-          )
-      );
 
       IncentiveKey memory key = IncentiveKey(
         rewardToken,

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -124,11 +124,14 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
 
     function createIncentiveWithMaxRange(
       IERC20Minimal rewardToken,
-      IUniswapV3Pool pool,
+      IUniswapV3Factory factory,
       uint256 startTime,
       uint256 endTime,
       address refundee,
-      uint256 reward
+      uint256 reward,
+      address token0;
+      address token1;
+      uint24 fee;
     ) external override {
       int24 tickSpacing = IUniswapV3Pool(pool).tickSpacing();
 

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -119,48 +119,47 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
 
         TransferHelperExtended.safeTransferFrom(address(key.rewardToken), msg.sender, address(this), reward);
 
-        emit IncentiveCreated(key.rewardToken, key.pool, key.startTime, key.endTime, key.minWidth, key.refundee, reward);
+        emit IncentiveCreated(
+            key.rewardToken,
+            key.pool,
+            key.startTime,
+            key.endTime,
+            key.minWidth,
+            key.refundee,
+            reward
+        );
     }
 
     function createIncentiveWithMaxRange(
-      IERC20Minimal rewardToken,
-      uint256 startTime,
-      uint256 endTime,
-      address refundee,
-      uint256 reward,
-      address token0,
-      address token1,
-      uint24 fee
+        IERC20Minimal rewardToken,
+        uint256 startTime,
+        uint256 endTime,
+        address refundee,
+        uint256 reward,
+        address token0,
+        address token1,
+        uint24 fee
     ) external override {
-      IUniswapV3Pool pool = IUniswapV3Pool(
-          PoolAddress.computeAddress(
-              address(factory),
-              PoolAddress.PoolKey({token0: token0, token1: token1, fee: fee})
-          )
-      );
+        IUniswapV3Pool pool =
+            IUniswapV3Pool(
+                PoolAddress.computeAddress(
+                    address(factory),
+                    PoolAddress.PoolKey({token0: token0, token1: token1, fee: fee})
+                )
+            );
 
-      int24 tickSpacing = IUniswapV3Pool(pool).tickSpacing();
+        int24 tickSpacing = IUniswapV3Pool(pool).tickSpacing();
 
-      // full range max/min ticks for pool
-      int24 maxTick = TickMath.MAX_TICK - TickMath.MAX_TICK % tickSpacing;
-      int24 minTick = - maxTick;
+        // full range max/min ticks for pool
+        int24 maxTick = TickMath.MAX_TICK - (TickMath.MAX_TICK % tickSpacing);
+        int24 minTick = -maxTick;
 
-      // use max range for min width
-      int24 minWidth = maxTick - minTick; // which is just 2 * maxTick
+        // use max range for min width
+        int24 minWidth = maxTick - minTick; // which is just 2 * maxTick
 
+        IncentiveKey memory key = IncentiveKey(rewardToken, pool, startTime, endTime, minWidth, refundee);
 
-      IncentiveKey memory key = IncentiveKey(
-        rewardToken,
-        pool,
-        startTime,
-        endTime,
-        minWidth,
-        refundee
-      );
-
-      // require(key.minWidth == TickMath.MAX_TICK * 2, 'UniswapV3Staker::createIncentiveWithMaxRange: minWidth not set to max tick range');
-
-      createIncentive(key, reward);
+        createIncentive(key, reward);
     }
 
     /// @inheritdoc IUniswapV3Staker
@@ -371,7 +370,10 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
 
         require(pool == key.pool, 'UniswapV3Staker::stakeToken: token pool is not the incentive pool');
         require(liquidity > 0, 'UniswapV3Staker::stakeToken: cannot stake token with 0 liquidity');
-        require(tickUpper - tickLower >= key.minWidth, 'UniswapV3Staker::stakeToken: range must be larger than minWidth');
+        require(
+            tickUpper - tickLower >= key.minWidth,
+            'UniswapV3Staker::stakeToken: range must be larger than minWidth'
+        );
 
         deposits[tokenId].numberOfStakes++;
         incentives[incentiveId].numberOfStakes++;

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -142,6 +142,13 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
       // use max range for min width
       int24 minWidth = maxTick - minTick; // which is just 2 * maxTick
 
+      pool = IUniswapV3Pool(
+          PoolAddress.computeAddress(
+              address(factory),
+              PoolAddress.PoolKey({token0: token0, token1: token1, fee: fee})
+          )
+      );
+      
       IncentiveKey memory key = IncentiveKey(
         rewardToken,
         pool,

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -11,6 +11,7 @@ import './libraries/TransferHelperExtended.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import '@uniswap/v3-core/contracts/interfaces/IERC20Minimal.sol';
+import '@uniswap/v3-core/contracts/interfaces/TickMath.sol';
 
 import '@uniswap/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol';
 import '@uniswap/v3-periphery/contracts/base/Multicall.sol';
@@ -122,7 +123,7 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
     }
 
     function createIncentiveWithMaxRange(IncentiveKey memory key, uint256 reward) external override {
-        // key.minWidth = max_range_value;
+        key.minWidth = TickMath.MAX_TICK * 2;
 
         createIncentive(key, reward);
     }

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -123,11 +123,11 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
     }
 
     function createIncentiveWithMaxRange(
-      IERC20Minimal rewardToken
-      IUniswapV3Pool pool
-      uint256 startTime
-      uint256 endTime
-      address refundee
+      IERC20Minimal rewardToken,
+      IUniswapV3Pool pool,
+      uint256 startTime,
+      uint256 endTime,
+      address refundee,
       uint256 reward
     ) external override {
       int24 tickSpacing = IUniswapV3Pool(pool).tickSpacing();
@@ -139,14 +139,14 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
       // use max range for min width
       int24 minWidth = maxTick - minTick; // which is just 2 * maxTick
 
-      IncentiveKey memory key = IncentiveKey({
+      IncentiveKey memory key = IncentiveKey(
         rewardToken,
         pool,
         startTime,
         endTime,
         minWidth,
         refundee
-      });
+      );
 
       // require(key.minWidth == TickMath.MAX_TICK * 2, 'UniswapV3Staker::createIncentiveWithMaxRange: minWidth not set to max tick range');
 

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -95,7 +95,7 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
     }
 
     /// @inheritdoc IUniswapV3Staker
-    function createIncentive(IncentiveKey memory key, uint256 reward) external override {
+    function createIncentive(IncentiveKey memory key, uint256 reward) public override {
         require(reward > 0, 'UniswapV3Staker::createIncentive: reward must be positive');
         require(
             block.timestamp <= key.startTime,

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -124,14 +124,13 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
 
     function createIncentiveWithMaxRange(
       IERC20Minimal rewardToken,
-      IUniswapV3Factory factory,
       uint256 startTime,
       uint256 endTime,
       address refundee,
       uint256 reward,
-      address token0;
-      address token1;
-      uint24 fee;
+      address token0,
+      address token1,
+      uint24 fee
     ) external override {
       int24 tickSpacing = IUniswapV3Pool(pool).tickSpacing();
 
@@ -148,7 +147,7 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
               PoolAddress.PoolKey({token0: token0, token1: token1, fee: fee})
           )
       );
-      
+
       IncentiveKey memory key = IncentiveKey(
         rewardToken,
         pool,

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -121,6 +121,12 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
         emit IncentiveCreated(key.rewardToken, key.pool, key.startTime, key.endTime, key.minWidth, key.refundee, reward);
     }
 
+    function createIncentiveWithMaxRange(IncentiveKey memory key, uint256 reward) external override {
+        // key.minWidth = max_range_value;
+
+        createIncentive(key, reward);
+    }
+
     /// @inheritdoc IUniswapV3Staker
     function endIncentive(IncentiveKey memory key) external override returns (uint256 refund) {
         require(block.timestamp >= key.endTime, 'UniswapV3Staker::endIncentive: cannot end incentive before end time');

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -125,6 +125,8 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
     function createIncentiveWithMaxRange(IncentiveKey memory key, uint256 reward) external override {
         key.minWidth = TickMath.MAX_TICK * 2;
 
+        require(key.minWidth == TickMath.MAX_TICK * 2, 'UniswapV3Staker::createIncentiveWithMaxRange: minWidth not set to max tick range');
+
         createIncentive(key, reward);
     }
 

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -122,12 +122,35 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
         emit IncentiveCreated(key.rewardToken, key.pool, key.startTime, key.endTime, key.minWidth, key.refundee, reward);
     }
 
-    function createIncentiveWithMaxRange(IncentiveKey memory key, uint256 reward) external override {
-        key.minWidth = TickMath.MAX_TICK * 2;
+    function createIncentiveWithMaxRange(
+      IERC20Minimal rewardToken
+      IUniswapV3Pool pool
+      uint256 startTime
+      uint256 endTime
+      address refundee
+      uint256 reward
+    ) external override {
+      int24 tickSpacing = IUniswapV3Pool(pool).tickSpacing();
 
-        require(key.minWidth == TickMath.MAX_TICK * 2, 'UniswapV3Staker::createIncentiveWithMaxRange: minWidth not set to max tick range');
+      // full range max/min ticks for pool
+      int24 maxTick = TickMath.MAX_TICK - TickMath.MAX_TICK % tickSpacing;
+      int24 minTick = - maxTick;
 
-        createIncentive(key, reward);
+      // use max range for min width
+      int24 minWidth = maxTick - minTick; // which is just 2 * maxTick
+
+      IncentiveKey memory key = IncentiveKey({
+        rewardToken,
+        pool,
+        startTime,
+        endTime,
+        minWidth,
+        refundee
+      });
+
+      // require(key.minWidth == TickMath.MAX_TICK * 2, 'UniswapV3Staker::createIncentiveWithMaxRange: minWidth not set to max tick range');
+
+      createIncentive(key, reward);
     }
 
     /// @inheritdoc IUniswapV3Staker

--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -11,7 +11,7 @@ import './libraries/TransferHelperExtended.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import '@uniswap/v3-core/contracts/interfaces/IERC20Minimal.sol';
-import '@uniswap/v3-core/contracts/interfaces/TickMath.sol';
+import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
 
 import '@uniswap/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol';
 import '@uniswap/v3-periphery/contracts/base/Multicall.sol';

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -96,7 +96,6 @@ interface IUniswapV3Staker is IERC721Receiver, IMulticall {
     /// @param reward The amount of reward tokens to be distributed
     function createIncentiveWithMaxRange(
       IERC20Minimal rewardToken,
-      IUniswapV3Pool pool,
       uint256 startTime,
       uint256 endTime,
       address refundee,

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -7,7 +7,7 @@ import '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import '@uniswap/v3-core/contracts/interfaces/IERC20Minimal.sol';
-import '@uniswap/v3-core/contracts/interfaces/TickMath.sol';
+import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
 
 import '@uniswap/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol';
 import '@uniswap/v3-periphery/contracts/interfaces/IMulticall.sol';

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -7,6 +7,7 @@ import '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import '@uniswap/v3-core/contracts/interfaces/IERC20Minimal.sol';
+import '@uniswap/v3-core/contracts/interfaces/TickMath.sol';
 
 import '@uniswap/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol';
 import '@uniswap/v3-periphery/contracts/interfaces/IMulticall.sol';

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -95,15 +95,15 @@ interface IUniswapV3Staker is IERC721Receiver, IMulticall {
     /// @notice Convenience function to create incentive setting minWidth param to max tick range
     /// @param reward The amount of reward tokens to be distributed
     function createIncentiveWithMaxRange(
-      IERC20Minimal rewardToken,
-      uint256 startTime,
-      uint256 endTime,
-      address refundee,
-      uint256 reward,
-      address token0,
-      address token1,
-      uint24 fee
-      ) external;
+        IERC20Minimal rewardToken,
+        uint256 startTime,
+        uint256 endTime,
+        address refundee,
+        uint256 reward,
+        address token0,
+        address token1,
+        uint24 fee
+    ) external;
 
     /// @notice Ends an incentive after the incentive end time has passed and all stakes have been withdrawn
     /// @param key Details of the incentive to end

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -91,6 +91,11 @@ interface IUniswapV3Staker is IERC721Receiver, IMulticall {
     /// @param reward The amount of reward tokens to be distributed
     function createIncentive(IncentiveKey memory key, uint256 reward) external;
 
+    /// @notice Convenience function to create incentive setting minWidth param to max tick range
+    /// @param key Details of the incentive to create
+    /// @param reward The amount of reward tokens to be distributed
+    function createIncentiveWithMaxRange(IncentiveKey memory key, uint256 reward) external;
+
     /// @notice Ends an incentive after the incentive end time has passed and all stakes have been withdrawn
     /// @param key Details of the incentive to end
     /// @return refund The remaining reward tokens when the incentive is ended

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -7,7 +7,6 @@ import '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import '@uniswap/v3-core/contracts/interfaces/IERC20Minimal.sol';
-import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
 
 import '@uniswap/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol';
 import '@uniswap/v3-periphery/contracts/interfaces/IMulticall.sol';

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -7,6 +7,7 @@ import '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import '@uniswap/v3-core/contracts/interfaces/IERC20Minimal.sol';
+import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
 
 import '@uniswap/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol';
 import '@uniswap/v3-periphery/contracts/interfaces/IMulticall.sol';

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -100,7 +100,11 @@ interface IUniswapV3Staker is IERC721Receiver, IMulticall {
       uint256 startTime,
       uint256 endTime,
       address refundee,
-      uint256 reward) external;
+      uint256 reward,
+      address token0,
+      address token1,
+      uint24 fee
+      ) external;
 
     /// @notice Ends an incentive after the incentive end time has passed and all stakes have been withdrawn
     /// @param key Details of the incentive to end

--- a/contracts/interfaces/IUniswapV3Staker.sol
+++ b/contracts/interfaces/IUniswapV3Staker.sol
@@ -93,9 +93,14 @@ interface IUniswapV3Staker is IERC721Receiver, IMulticall {
     function createIncentive(IncentiveKey memory key, uint256 reward) external;
 
     /// @notice Convenience function to create incentive setting minWidth param to max tick range
-    /// @param key Details of the incentive to create
     /// @param reward The amount of reward tokens to be distributed
-    function createIncentiveWithMaxRange(IncentiveKey memory key, uint256 reward) external;
+    function createIncentiveWithMaxRange(
+      IERC20Minimal rewardToken,
+      IUniswapV3Pool pool,
+      uint256 startTime,
+      uint256 endTime,
+      address refundee,
+      uint256 reward) external;
 
     /// @notice Ends an incentive after the incentive end time has passed and all stakes have been withdrawn
     /// @param key Details of the incentive to end

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -230,7 +230,7 @@ export const uniswapFixture: Fixture<UniswapFixtureType> = async (wallets, provi
 
   const fee = FeeAmount.MEDIUM
   const maxTickRange = 2 * getMaxTick(TICK_SPACINGS[FeeAmount.MEDIUM])
-  
+
   await nft.createAndInitializePoolIfNecessary(tokens[0].address, tokens[1].address, fee, encodePriceSqrt(1, 1))
 
   await nft.createAndInitializePoolIfNecessary(tokens[1].address, tokens[2].address, fee, encodePriceSqrt(1, 1))

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -73,7 +73,7 @@ type UniswapFactoryFixture = {
   factory: IUniswapV3Factory
   router: ISwapRouter
   nft: INonfungiblePositionManager
-  tokens: [TestERC20, TestERC20, TestERC20]
+  tokens: [TestERC20, TestERC20, TestERC20, TestERC20]
 }
 
 export const uniswapFactoryFixture: Fixture<UniswapFactoryFixture> = async (wallets, provider) => {
@@ -83,7 +83,8 @@ export const uniswapFactoryFixture: Fixture<UniswapFactoryFixture> = async (wall
     tokenFactory.deploy(constants.MaxUint256.div(2)), // do not use maxu256 to avoid overflowing
     tokenFactory.deploy(constants.MaxUint256.div(2)),
     tokenFactory.deploy(constants.MaxUint256.div(2)),
-  ])) as [TestERC20, TestERC20, TestERC20]
+    tokenFactory.deploy(constants.MaxUint256.div(2)),
+  ])) as [TestERC20, TestERC20, TestERC20, TestERC20]
 
   const nftDescriptorLibrary = await nftDescriptorLibraryFixture(wallets, provider)
 
@@ -204,13 +205,16 @@ export type UniswapFixtureType = {
   nft: INonfungiblePositionManager
   pool01: string
   pool12: string
+  pool13: string
   poolObj: IUniswapV3Pool
+  poolObj1: IUniswapV3Pool
   router: ISwapRouter
   staker: UniswapV3Staker
   testIncentiveId: TestIncentiveId
-  tokens: [TestERC20, TestERC20, TestERC20]
+  tokens: [TestERC20, TestERC20, TestERC20, TestERC20]
   token0: TestERC20
   token1: TestERC20
+  token3: TestERC20
   rewardToken: TestERC20
   minWidth: number
   maxTickRange: number
@@ -229,17 +233,23 @@ export const uniswapFixture: Fixture<UniswapFixtureType> = async (wallets, provi
   }
 
   const fee = FeeAmount.MEDIUM
+  const fee1 = FeeAmount.HIGH
   const maxTickRange = 2 * getMaxTick(TICK_SPACINGS[FeeAmount.MEDIUM])
 
   await nft.createAndInitializePoolIfNecessary(tokens[0].address, tokens[1].address, fee, encodePriceSqrt(1, 1))
 
   await nft.createAndInitializePoolIfNecessary(tokens[1].address, tokens[2].address, fee, encodePriceSqrt(1, 1))
 
+  await nft.createAndInitializePoolIfNecessary(tokens[1].address, tokens[3].address, fee1, encodePriceSqrt(1, 1))
+
   const pool01 = await factory.getPool(tokens[0].address, tokens[1].address, fee)
 
   const pool12 = await factory.getPool(tokens[1].address, tokens[2].address, fee)
 
+  const pool13 = await factory.getPool(tokens[1].address, tokens[3].address, fee1)
+
   const poolObj = poolFactory.attach(pool01) as IUniswapV3Pool
+  const poolObj1 = poolFactory.attach(pool13) as IUniswapV3Pool
 
   return {
     nft,
@@ -250,10 +260,13 @@ export const uniswapFixture: Fixture<UniswapFixtureType> = async (wallets, provi
     factory,
     pool01,
     pool12,
+    pool13,
     fee,
     poolObj,
+    poolObj1,
     token0: tokens[0],
     token1: tokens[1],
+    token3: tokens[3],
     rewardToken: tokens[2],
     minWidth: 333,
     maxTickRange,

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -230,6 +230,7 @@ export const uniswapFixture: Fixture<UniswapFixtureType> = async (wallets, provi
 
   const fee = FeeAmount.MEDIUM
   const maxTickRange = 2 * getMaxTick(TICK_SPACINGS[FeeAmount.MEDIUM])
+  
   await nft.createAndInitializePoolIfNecessary(tokens[0].address, tokens[1].address, fee, encodePriceSqrt(1, 1))
 
   await nft.createAndInitializePoolIfNecessary(tokens[1].address, tokens[2].address, fee, encodePriceSqrt(1, 1))

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -21,7 +21,7 @@ import {
   TestIncentiveId,
 } from '../../typechain'
 import { NFTDescriptor } from '../../types/NFTDescriptor'
-import { FeeAmount, BigNumber, encodePriceSqrt, MAX_GAS_LIMIT } from '../shared'
+import { FeeAmount, BigNumber, encodePriceSqrt, MAX_GAS_LIMIT, getMaxTick, TICK_SPACINGS } from '../shared'
 import { ActorFixture } from './actors'
 
 type WETH9Fixture = { weth9: IWETH9 }
@@ -213,6 +213,7 @@ export type UniswapFixtureType = {
   token1: TestERC20
   rewardToken: TestERC20
   minWidth: number
+  maxTickRange: number
 }
 export const uniswapFixture: Fixture<UniswapFixtureType> = async (wallets, provider) => {
   const { tokens, nft, factory, router } = await uniswapFactoryFixture(wallets, provider)
@@ -228,6 +229,7 @@ export const uniswapFixture: Fixture<UniswapFixtureType> = async (wallets, provi
   }
 
   const fee = FeeAmount.MEDIUM
+  const maxTickRange = 2 * getMaxTick(TICK_SPACINGS[FeeAmount.MEDIUM])
   await nft.createAndInitializePoolIfNecessary(tokens[0].address, tokens[1].address, fee, encodePriceSqrt(1, 1))
 
   await nft.createAndInitializePoolIfNecessary(tokens[1].address, tokens[2].address, fee, encodePriceSqrt(1, 1))
@@ -253,6 +255,7 @@ export const uniswapFixture: Fixture<UniswapFixtureType> = async (wallets, provi
     token1: tokens[1],
     rewardToken: tokens[2],
     minWidth: 333,
+    maxTickRange,
   }
 }
 

--- a/test/unit/Deposits.spec.ts
+++ b/test/unit/Deposits.spec.ts
@@ -25,7 +25,7 @@ import { HelperTypes } from '../helpers/types'
 
 let loadFixture: LoadFixtureFunction
 
-describe.only('unit/Deposits', () => {
+describe('unit/Deposits', () => {
   const actors = new ActorFixture(provider.getWallets(), provider)
   const lpUser0 = actors.lpUser0()
   const amountDesired = BNe18(10)
@@ -137,12 +137,6 @@ describe.only('unit/Deposits', () => {
     })
 
     it('allows depositing and staking for a single incentive', async () => {
-      // const data = ethers.utils.defaultAbiCoder.encode(
-      //   [INCENTIVE_KEY_ABI],
-      //   [incentiveResultToStakeAdapter(createIncentiveResult)]
-      // )
-
-      // swap for syntax below and single staked incentive test passes
       const data = ethers.utils.defaultAbiCoder.encode(
         [`${INCENTIVE_KEY_ABI}[]`],
         [[createIncentiveResult].map(incentiveResultToStakeAdapter)]
@@ -263,8 +257,6 @@ describe.only('unit/Deposits', () => {
 
       const incentiveKey: ContractParams.IncentiveKey = incentiveResultToStakeAdapter(incentive)
 
-      // data = ethers.utils.defaultAbiCoder.encode([incentiveKeyAbi], [incentiveKey])
-
       data = ethers.utils.defaultAbiCoder.encode(
         [`${incentiveKeyAbi}[]`],
         [[incentive].map(incentiveResultToStakeAdapter)]
@@ -351,9 +343,6 @@ describe.only('unit/Deposits', () => {
           refundee: incentiveCreator.address,
         }
 
-        // let invalidData = ethers.utils.defaultAbiCoder.encode([`${incentiveKeyAbi}[]`], [invalidStakeParams])
-
-        // swap for syntax below and invalid test passes
         let invalidData = ethers.utils.defaultAbiCoder.encode(
           [`${incentiveKeyAbi}[]`],
           [[invalidStakeParams].map(incentiveResultToStakeAdapter)]

--- a/test/unit/Deposits.spec.ts
+++ b/test/unit/Deposits.spec.ts
@@ -361,19 +361,36 @@ describe('unit/Deposits', () => {
       })
 
       it('reverts when attempting to stake token with tick range less than minWidth', async () => {
+        const { rewardToken, minWidth } = context
+        timestamps = makeTimestamps((await blockTimestamp()) + 1_000)
+        const incentive1 = await helpers.createIncentiveFlow({
+          rewardToken,
+          totalReward,
+          poolAddress: context.poolObj1.address,
+          ...timestamps,
+          minWidth,
+        })
+
+        const incentiveKey: ContractParams.IncentiveKey = incentiveResultToStakeAdapter(incentive1)
+
+        data = ethers.utils.defaultAbiCoder.encode(
+          [`${incentiveKeyAbi}[]`],
+          [[incentive1].map(incentiveResultToStakeAdapter)]
+        )
+
         await Time.set(timestamps.startTime + 500)
         await erc20Helper.ensureBalancesAndApprovals(
           lpUser0,
-          [context.token0, context.token1],
+          [context.token1, context.token3],
           amountDesired,
           context.nft.address
         )
         const tokenId2 = await mintPosition(context.nft.connect(lpUser0), {
-          token0: context.token0.address,
-          token1: context.token1.address,
-          fee: FeeAmount.MEDIUM,
+          token0: context.token1.address,
+          token1: context.token3.address,
+          fee: FeeAmount.HIGH,
           tickLower: 0,
-          tickUpper: TICK_SPACINGS[FeeAmount.MEDIUM],
+          tickUpper: TICK_SPACINGS[FeeAmount.HIGH],
           recipient: lpUser0.address,
           amount0Desired: amountDesired,
           amount1Desired: amountDesired,

--- a/test/unit/Deposits.spec.ts
+++ b/test/unit/Deposits.spec.ts
@@ -25,7 +25,7 @@ import { HelperTypes } from '../helpers/types'
 
 let loadFixture: LoadFixtureFunction
 
-describe.only('unit/Deposits', () => {
+describe('unit/Deposits', () => {
   const actors = new ActorFixture(provider.getWallets(), provider)
   const lpUser0 = actors.lpUser0()
   const amountDesired = BNe18(10)
@@ -384,16 +384,17 @@ describe.only('unit/Deposits', () => {
 
         await expect(
           context.nft
-          .connect(lpUser0)
-          ['safeTransferFrom(address,address,uint256,bytes)'](
-            lpUser0.address, 
-            context.staker.address, 
-            tokenId2,
-            data, {
-              ...maxGas,
-              from: lpUser0.address,
-            }
-          )
+            .connect(lpUser0)
+            ['safeTransferFrom(address,address,uint256,bytes)'](
+              lpUser0.address,
+              context.staker.address,
+              tokenId2,
+              data,
+              {
+                ...maxGas,
+                from: lpUser0.address,
+              }
+            )
         ).to.be.revertedWith('UniswapV3Staker::stakeToken: range must be larger than minWidth')
       })
     })

--- a/test/unit/Deposits.spec.ts
+++ b/test/unit/Deposits.spec.ts
@@ -25,7 +25,7 @@ import { HelperTypes } from '../helpers/types'
 
 let loadFixture: LoadFixtureFunction
 
-describe('unit/Deposits', () => {
+describe.only('unit/Deposits', () => {
   const actors = new ActorFixture(provider.getWallets(), provider)
   const lpUser0 = actors.lpUser0()
   const amountDesired = BNe18(10)
@@ -369,6 +369,50 @@ describe('unit/Deposits', () => {
               invalidData
             )
         ).to.be.revertedWith('UniswapV3Staker::stakeToken: non-existent incentive')
+      })
+
+      it('reverts when attempting to stake token with tick range less than minWidth', async () => {
+        await Time.set(timestamps.startTime + 500)
+        await erc20Helper.ensureBalancesAndApprovals(
+          lpUser0,
+          [context.token0, context.token1],
+          amountDesired,
+          context.nft.address
+        )
+        const tokenId2 = await mintPosition(context.nft.connect(lpUser0), {
+          token0: context.token0.address,
+          token1: context.token1.address,
+          fee: FeeAmount.MEDIUM,
+          tickLower: 0,
+          tickUpper: 5 * TICK_SPACINGS[FeeAmount.MEDIUM],
+          recipient: lpUser0.address,
+          amount0Desired: amountDesired,
+          amount1Desired: amountDesired,
+          amount0Min: 0,
+          amount1Min: 0,
+          deadline: (await blockTimestamp()) + 1000,
+        })
+
+        await context.nft
+          .connect(lpUser0)
+          ['safeTransferFrom(address,address,uint256)'](lpUser0.address, context.staker.address, tokenId2, {
+            ...maxGas,
+            from: lpUser0.address,
+          })
+
+        await expect(
+          context.staker.connect(lpUser0).stakeToken(
+            {
+              rewardToken: context.rewardToken.address,
+              pool: context.pool01,
+              startTime: timestamps.startTime,
+              endTime: timestamps.endTime,
+              refundee: incentiveCreator.address,
+              minWidth: context.minWidth,
+            },
+            tokenId2
+          )
+        ).to.be.revertedWith('UniswapV3Staker::stakeToken: range must be larger than minWidth')
       })
     })
   })

--- a/test/unit/Deposits.spec.ts
+++ b/test/unit/Deposits.spec.ts
@@ -25,7 +25,7 @@ import { HelperTypes } from '../helpers/types'
 
 let loadFixture: LoadFixtureFunction
 
-describe('unit/Deposits', () => {
+describe.only('unit/Deposits', () => {
   const actors = new ActorFixture(provider.getWallets(), provider)
   const lpUser0 = actors.lpUser0()
   const amountDesired = BNe18(10)
@@ -373,7 +373,7 @@ describe('unit/Deposits', () => {
           token1: context.token1.address,
           fee: FeeAmount.MEDIUM,
           tickLower: 0,
-          tickUpper: 5 * TICK_SPACINGS[FeeAmount.MEDIUM],
+          tickUpper: TICK_SPACINGS[FeeAmount.MEDIUM],
           recipient: lpUser0.address,
           amount0Desired: amountDesired,
           amount1Desired: amountDesired,
@@ -382,24 +382,17 @@ describe('unit/Deposits', () => {
           deadline: (await blockTimestamp()) + 1000,
         })
 
-        await context.nft
-          .connect(lpUser0)
-          ['safeTransferFrom(address,address,uint256)'](lpUser0.address, context.staker.address, tokenId2, {
-            ...maxGas,
-            from: lpUser0.address,
-          })
-
         await expect(
-          context.staker.connect(lpUser0).stakeToken(
-            {
-              rewardToken: context.rewardToken.address,
-              pool: context.pool01,
-              startTime: timestamps.startTime,
-              endTime: timestamps.endTime,
-              refundee: incentiveCreator.address,
-              minWidth: context.minWidth,
-            },
-            tokenId2
+          context.nft
+          .connect(lpUser0)
+          ['safeTransferFrom(address,address,uint256,bytes)'](
+            lpUser0.address, 
+            context.staker.address, 
+            tokenId2,
+            data, {
+              ...maxGas,
+              from: lpUser0.address,
+            }
           )
         ).to.be.revertedWith('UniswapV3Staker::stakeToken: range must be larger than minWidth')
       })

--- a/test/unit/Incentives.spec.ts
+++ b/test/unit/Incentives.spec.ts
@@ -348,26 +348,6 @@ describe('unit/Incentives', async () => {
     })
   })
 
-  // describe('fails when', () => {
-  //   it('when param minWidth is not set to max tick range', async () => {
-  //     const now = await blockTimestamp();
-
-  //     await expect(
-  //       context.staker.connect(incentiveCreator).createIncentive(
-  //         {
-  //           rewardToken: context.rewardToken.address,
-  //           pool: context.pool01,
-  //           refundee: incentiveCreator.address,
-  //           ...makeTimestamps(now, 1_000),
-  //           minWidth: context.minWidth,
-  //         },
-  //         BNe18(0)
-  //       )
-  //     ).to.be.revertedWith('UniswapV3Staker::createIncentive: reward must be positive')
-  //   })
-  // })
-  // })
-
   describe('#endIncentive', () => {
     let subject: (params: Partial<ContractParams.EndIncentive>) => Promise<any>
     let createIncentiveResult: HelperTypes.CreateIncentive.Result

--- a/test/unit/Incentives.spec.ts
+++ b/test/unit/Incentives.spec.ts
@@ -22,7 +22,7 @@ import { HelperTypes } from '../helpers/types'
 
 let loadFixture: LoadFixtureFunction
 
-describe('unit/Incentives', async () => {
+describe.only('unit/Incentives', async () => {
   const actors = new ActorFixture(provider.getWallets(), provider)
   const incentiveCreator = actors.incentiveCreator()
   const totalReward = BNe18(100)
@@ -266,6 +266,8 @@ describe('unit/Incentives', async () => {
         it('minWidth is 0 or less', async () => {
           const now = await blockTimestamp()
 
+          console.log('getMaxTick: ', getMaxTick(TICK_SPACINGS[FeeAmount.MEDIUM]));
+
           await expect(
             context.staker.connect(incentiveCreator).createIncentive(
               {
@@ -283,65 +285,65 @@ describe('unit/Incentives', async () => {
     })
   })
 
-  describe('#createIncentiveWithMaxRange', () => {
-    let subject: (params: Partial<ContractParams.CreateIncentive>) => Promise<any>;
+  // describe('#createIncentiveWithMaxRange', () => {
+  //   let subject: (params: Partial<ContractParams.CreateIncentive>) => Promise<any>;
 
-    beforeEach('setup', async () => {
-      subject = async (params: Partial<ContractParams.CreateIncentive> = {}) => {
-        await erc20Helper.ensureBalancesAndApprovals(
-          incentiveCreator,
-          params.rewardToken ? await erc20Wrap(params?.rewardToken) : context.rewardToken,
-          totalReward,
-          context.staker.address
-        )
+  //   beforeEach('setup', async () => {
+  //     subject = async (params: Partial<ContractParams.CreateIncentive> = {}) => {
+  //       await erc20Helper.ensureBalancesAndApprovals(
+  //         incentiveCreator,
+  //         params.rewardToken ? await erc20Wrap(params?.rewardToken) : context.rewardToken,
+  //         totalReward,
+  //         context.staker.address
+  //       )
 
-        const { startTime, endTime } = makeTimestamps(await blockTimestamp())
+  //       const { startTime, endTime } = makeTimestamps(await blockTimestamp())
 
-        await context.staker.connect(incentiveCreator).createIncentiveWithMaxRange(
-          {
-            rewardToken: params.rewardToken || context.rewardToken.address,
-            pool: context.pool01,
-            startTime: params.startTime || startTime,
-            endTime: params.endTime || endTime,
-            refundee: params.refundee || incentiveCreator.address,
-            minWidth: params.minWidth || context.minWidth,
-          },
-          totalReward
-        )
+  //       await context.staker.connect(incentiveCreator).createIncentiveWithMaxRange(
+  //         {
+  //           rewardToken: params.rewardToken || context.rewardToken.address,
+  //           pool: context.pool01,
+  //           startTime: params.startTime || startTime,
+  //           endTime: params.endTime || endTime,
+  //           refundee: params.refundee || incentiveCreator.address,
+  //           minWidth: params.minWidth || context.minWidth,
+  //         },
+  //         totalReward
+  //       )
 
-        await expect(subject({ startTime, endTime }))
-          .to.emit(context.staker, 'IncentiveCreated')
-          .withArgs(
-            context.rewardToken.address,
-            context.pool01,
-            startTime,
-            endTime,
-            context.maxTickRange,
-            incentiveCreator.address,
-            totalReward
-          )
-      }
-    })
+  //       await expect(subject({ startTime, endTime }))
+  //         .to.emit(context.staker, 'IncentiveCreated')
+  //         .withArgs(
+  //           context.rewardToken.address,
+  //           context.pool01,
+  //           startTime,
+  //           endTime,
+  //           context.maxTickRange,
+  //           incentiveCreator.address,
+  //           totalReward
+  //         )
+  //     }
+  //   })
 
-    describe('fails when', () => {
-      it('when param minWidth is not set to max tick range', async () => {
-        const now = await blockTimestamp();
+  //   describe('fails when', () => {
+  //     it('when param minWidth is not set to max tick range', async () => {
+  //       const now = await blockTimestamp();
 
-        await expect(
-          context.staker.connect(incentiveCreator).createIncentive(
-            {
-              rewardToken: context.rewardToken.address,
-              pool: context.pool01,
-              refundee: incentiveCreator.address,
-              ...makeTimestamps(now, 1_000),
-              minWidth: context.minWidth,
-            },
-            BNe18(0)
-          )
-        ).to.be.revertedWith('UniswapV3Staker::createIncentive: reward must be positive')
-      })
-    })
-  })
+  //       await expect(
+  //         context.staker.connect(incentiveCreator).createIncentive(
+  //           {
+  //             rewardToken: context.rewardToken.address,
+  //             pool: context.pool01,
+  //             refundee: incentiveCreator.address,
+  //             ...makeTimestamps(now, 1_000),
+  //             minWidth: context.minWidth,
+  //           },
+  //           BNe18(0)
+  //         )
+  //       ).to.be.revertedWith('UniswapV3Staker::createIncentive: reward must be positive')
+  //     })
+  //   })
+  // })
 
   describe('#endIncentive', () => {
     let subject: (params: Partial<ContractParams.EndIncentive>) => Promise<any>

--- a/test/unit/Incentives.spec.ts
+++ b/test/unit/Incentives.spec.ts
@@ -283,6 +283,66 @@ describe('unit/Incentives', async () => {
     })
   })
 
+  describe('#createIncentiveWithMaxRange', () => {
+    let subject: (params: Partial<ContractParams.CreateIncentive>) => Promise<any>;
+
+    beforeEach('setup', async () => {
+      subject = async (params: Partial<ContractParams.CreateIncentive> = {}) => {
+        await erc20Helper.ensureBalancesAndApprovals(
+          incentiveCreator,
+          params.rewardToken ? await erc20Wrap(params?.rewardToken) : context.rewardToken,
+          totalReward,
+          context.staker.address
+        )
+
+        const { startTime, endTime } = makeTimestamps(await blockTimestamp())
+
+        await context.staker.connect(incentiveCreator).createIncentiveWithMaxRange(
+          {
+            rewardToken: params.rewardToken || context.rewardToken.address,
+            pool: context.pool01,
+            startTime: params.startTime || startTime,
+            endTime: params.endTime || endTime,
+            refundee: params.refundee || incentiveCreator.address,
+            minWidth: params.minWidth || context.minWidth,
+          },
+          totalReward
+        )
+
+        await expect(subject({ startTime, endTime }))
+          .to.emit(context.staker, 'IncentiveCreated')
+          .withArgs(
+            context.rewardToken.address,
+            context.pool01,
+            startTime,
+            endTime,
+            context.maxTickRange,
+            incentiveCreator.address,
+            totalReward
+          )
+      }
+    })
+
+    describe('fails when', () => {
+      it('when param minWidth is not set to max tick range', async () => {
+        const now = await blockTimestamp();
+
+        await expect(
+          context.staker.connect(incentiveCreator).createIncentive(
+            {
+              rewardToken: context.rewardToken.address,
+              pool: context.pool01,
+              refundee: incentiveCreator.address,
+              ...makeTimestamps(now, 1_000),
+              minWidth: context.minWidth,
+            },
+            BNe18(0)
+          )
+        ).to.be.revertedWith('UniswapV3Staker::createIncentive: reward must be positive')
+      })
+    })
+  })
+
   describe('#endIncentive', () => {
     let subject: (params: Partial<ContractParams.EndIncentive>) => Promise<any>
     let createIncentiveResult: HelperTypes.CreateIncentive.Result

--- a/test/unit/__snapshots__/Deposits.spec.ts.snap
+++ b/test/unit/__snapshots__/Deposits.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `217096`;
+exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `217125`;
 
-exports[`unit/Deposits #transferDeposit has gas cost 1`] = `29200`;
+exports[`unit/Deposits #transferDeposit has gas cost 1`] = `29222`;
 
-exports[`unit/Deposits #withdrawToken works and has gas cost 1`] = `75965`;
+exports[`unit/Deposits #withdrawToken works and has gas cost 1`] = `75942`;

--- a/test/unit/__snapshots__/Deposits.spec.ts.snap
+++ b/test/unit/__snapshots__/Deposits.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `217125`;
+exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `217113`;
 
 exports[`unit/Deposits #transferDeposit has gas cost 1`] = `29222`;
 

--- a/test/unit/__snapshots__/Deposits.spec.ts.snap
+++ b/test/unit/__snapshots__/Deposits.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `217113`;
+exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `217101`;
 
 exports[`unit/Deposits #transferDeposit has gas cost 1`] = `29222`;
 

--- a/test/unit/__snapshots__/Deposits.spec.ts.snap
+++ b/test/unit/__snapshots__/Deposits.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `217101`;
+exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `217125`;
 
 exports[`unit/Deposits #transferDeposit has gas cost 1`] = `29222`;
 

--- a/test/unit/__snapshots__/Deposits.spec.ts.snap
+++ b/test/unit/__snapshots__/Deposits.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `217125`;
+exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `217137`;
 
 exports[`unit/Deposits #transferDeposit has gas cost 1`] = `29222`;
 

--- a/test/unit/__snapshots__/Incentives.spec.ts.snap
+++ b/test/unit/__snapshots__/Incentives.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Incentives #createIncentive works and has gas cost 1`] = `58340`;
+exports[`unit/Incentives #createIncentive works and has gas cost 1`] = `58364`;
 
-exports[`unit/Incentives #endIncentive works and has gas cost 1`] = `35988`;
+exports[`unit/Incentives #endIncentive works and has gas cost 1`] = `36012`;

--- a/test/unit/__snapshots__/Incentives.spec.ts.snap
+++ b/test/unit/__snapshots__/Incentives.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Incentives #createIncentive works and has gas cost 1`] = `58364`;
+exports[`unit/Incentives #createIncentive works and has gas cost 1`] = `58340`;
 
-exports[`unit/Incentives #endIncentive works and has gas cost 1`] = `36012`;
+exports[`unit/Incentives #endIncentive works and has gas cost 1`] = `35988`;

--- a/test/unit/__snapshots__/Incentives.spec.ts.snap
+++ b/test/unit/__snapshots__/Incentives.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Incentives #createIncentive works and has gas cost 1`] = `58408`;
+exports[`unit/Incentives #createIncentive works and has gas cost 1`] = `58364`;
 
 exports[`unit/Incentives #endIncentive works and has gas cost 1`] = `36012`;

--- a/test/unit/__snapshots__/Multicall.spec.ts.snap
+++ b/test/unit/__snapshots__/Multicall.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Multicall can be used to exit a position from multiple incentives 1`] = `197236`;
+exports[`unit/Multicall can be used to exit a position from multiple incentives 1`] = `197347`;
 
 exports[`unit/Multicall can be used to stake an already deposited token for multiple incentives 1`] = `243102`;

--- a/test/unit/__snapshots__/Multicall.spec.ts.snap
+++ b/test/unit/__snapshots__/Multicall.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Multicall can be used to exit a position from multiple incentives 1`] = `197347`;
+exports[`unit/Multicall can be used to exit a position from multiple incentives 1`] = `197299`;
 
-exports[`unit/Multicall can be used to stake an already deposited token for multiple incentives 1`] = `243102`;
+exports[`unit/Multicall can be used to stake an already deposited token for multiple incentives 1`] = `243030`;

--- a/test/unit/__snapshots__/Multicall.spec.ts.snap
+++ b/test/unit/__snapshots__/Multicall.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Multicall can be used to exit a position from multiple incentives 1`] = `197299`;
+exports[`unit/Multicall can be used to exit a position from multiple incentives 1`] = `197347`;
 
-exports[`unit/Multicall can be used to stake an already deposited token for multiple incentives 1`] = `243030`;
+exports[`unit/Multicall can be used to stake an already deposited token for multiple incentives 1`] = `243102`;

--- a/test/unit/__snapshots__/Multicall.spec.ts.snap
+++ b/test/unit/__snapshots__/Multicall.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Multicall can be used to exit a position from multiple incentives 1`] = `197347`;
+exports[`unit/Multicall can be used to exit a position from multiple incentives 1`] = `197371`;
 
-exports[`unit/Multicall can be used to stake an already deposited token for multiple incentives 1`] = `243102`;
+exports[`unit/Multicall can be used to stake an already deposited token for multiple incentives 1`] = `243138`;

--- a/test/unit/__snapshots__/Stakes.spec.ts.snap
+++ b/test/unit/__snapshots__/Stakes.spec.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`unit/Stakes #claimReward when requesting the full amount has gas cost 1`] = `47643`;
 
-exports[`unit/Stakes #stakeToken works and has gas cost 1`] = `115768`;
+exports[`unit/Stakes #stakeToken works and has gas cost 1`] = `115792`;
 
-exports[`unit/Stakes #unstakeToken works and has gas cost 1`] = `71612`;
+exports[`unit/Stakes #unstakeToken works and has gas cost 1`] = `71636`;

--- a/test/unit/__snapshots__/Stakes.spec.ts.snap
+++ b/test/unit/__snapshots__/Stakes.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Stakes #claimReward when requesting the full amount has gas cost 1`] = `47621`;
+exports[`unit/Stakes #claimReward when requesting the full amount has gas cost 1`] = `47643`;
 
 exports[`unit/Stakes #stakeToken works and has gas cost 1`] = `115792`;
 
-exports[`unit/Stakes #unstakeToken works and has gas cost 1`] = `71591`;
+exports[`unit/Stakes #unstakeToken works and has gas cost 1`] = `71636`;

--- a/test/unit/__snapshots__/Stakes.spec.ts.snap
+++ b/test/unit/__snapshots__/Stakes.spec.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`unit/Stakes #claimReward when requesting the full amount has gas cost 1`] = `47643`;
 
-exports[`unit/Stakes #stakeToken works and has gas cost 1`] = `115792`;
+exports[`unit/Stakes #stakeToken works and has gas cost 1`] = `115768`;
 
-exports[`unit/Stakes #unstakeToken works and has gas cost 1`] = `71636`;
+exports[`unit/Stakes #unstakeToken works and has gas cost 1`] = `71612`;


### PR DESCRIPTION
- add `createIncentiveWithMaxRange` convenience function to `UniswapV3Staker.sol` & update interface. 
- `createIncentiveWithMaxRange()` function to take in individual params excluding `minWidth` param, using factory contract to determine V3 pool to create incentive with 2*max tick range set as `minWidth` to incentivize max range liquidity.
- test suite to complement new function added in `Incentives.spec.ts`
- unit test added in `Deposits.spec.ts`
- updated fixtures to include `poolObj1` to test other fee amounts
- updated snapshots 