### PR TITLE
update for invalid fee param check

### DIFF
--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -149,7 +149,7 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
             );
 
         int24 tickSpacing = factory.feeAmountTickSpacing(fee);
-        require(tickSpacing > 0, "staker: !fee");
+        require(tickSpacing > 0, 'UniswapV3Staker::createIncentiveWithMaxRange: !fee');
 
         // full range max/min ticks for pool
         int24 maxTick = TickMath.MAX_TICK - (TickMath.MAX_TICK % tickSpacing);

--- a/test/unit/Incentives.spec.ts
+++ b/test/unit/Incentives.spec.ts
@@ -346,6 +346,35 @@ describe('unit/Incentives', async () => {
         expect(incentive.totalSecondsClaimedX128).to.equal(BN(0))
       })
     })
+
+    describe('reverts when', () => {
+      it('invalid fee param passed in', async () => {
+        await erc20Helper.ensureBalancesAndApprovals(
+          incentiveCreator,
+          context.rewardToken,
+          totalReward,
+          context.staker.address
+        )
+
+        const { startTime, endTime } = makeTimestamps(await blockTimestamp())
+        const invalidFee = 0
+
+        await expect(
+          context.staker
+            .connect(incentiveCreator)
+            .createIncentiveWithMaxRange(
+              context.rewardToken.address,
+              startTime,
+              endTime,
+              incentiveCreator.address,
+              totalReward,
+              context.tokens[0].address,
+              context.tokens[1].address,
+              invalidFee
+            )
+        ).to.be.revertedWith('UniswapV3Staker::createIncentiveWithMaxRange: !fee')
+      })
+    })
   })
 
   describe('#endIncentive', () => {


### PR DESCRIPTION
- update invalid fee param revert message for `createIncentiveWithMaxRange()`
- add unit test in unit/Incentives.spec.ts testing for revert when invalid fee arg is passed